### PR TITLE
Build the entry point of cmd interpreter as specced.

### DIFF
--- a/console.py
+++ b/console.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+"""Entry point of the command interpreter."""
+
+import cmd
+
+
+class HBNBCommand(cmd.Cmd):
+    """The command processor's model."""
+
+    prompt = '(hbnb) '
+
+    def do_EOF(self, line):
+        """Command to exit interpreter when EOF is encountered."""
+        return True
+
+    def do_quit(self, line):
+        """Quit command to exit the program\n"""
+        return True
+
+    def emptyline(self):
+        """Override default emptyline() to do nothing."""
+        return
+
+
+if __name__ == '__main__':
+    HBNBCommand().cmdloop()


### PR DESCRIPTION
DONE: Write a program called console.py that contains the entry point of the command interpreter:

- You must use the module cmd
- Your class definition must be: class HBNBCommand(cmd.Cmd):
- Your command interpreter should implement:
- quit and EOF to exit the program
- help (this action is provided by default by cmd but you should keep it updated and documented as you work through tasks)
- a custom prompt: (hbnb)
- an empty line + ENTER shouldn’t execute anything
- Your code should not be executed when imported