### PR TITLE
Adjust all cmd for when model name passed as 2nd arg.

### DIFF
--- a/console.py
+++ b/console.py
@@ -85,7 +85,7 @@ class HBNBCommand(cmd.Cmd):
         else:
             coll_obj = storage.all()
             list_obj = [str(v) for k, v in coll_obj.items()
-                        if "BaseModel" == v.__class__.__name__]
+                        if line == v.__class__.__name__]
             print(list_obj)
 
     def do_update(self, line):


### PR DESCRIPTION
When all <model_name> is passed, it only outputs for BaseModel. So I adjusted the all method in console.py to work for any model name as long as it's in the list of models I've specified already.